### PR TITLE
update mapbox-gl-draw import statement to use dist version

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import MapboxDraw from '@mapbox/mapbox-gl-draw';
+import MapboxDraw from '@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw';
 
 export default class DrawControl extends React.Component {
   componentWillMount() {


### PR DESCRIPTION
Importing `mapbox-gl-draw` using the `@mapbox/mapbox-gl-draw` statement causes builds to break when using tools such as `create-react-app` (detailed [here](https://github.com/mapbox/mapbox-gl-draw/issues/725)). When using `mapbox-gl-draw` itself this is possible to amend within our own codebase but not when using `react-mapbox-gl-draw`.

Making the import statement more specific ensures the correct version is used.