### PR TITLE
fix: Add userProperties to DrawControlProps

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ export interface DrawControlProps {
   position?: 'bottom-left' | 'bottom-right' | 'top-left' | 'top-right';
   touchBuffer?: number;
   touchEnabled?: boolean;
+  userProperties?: boolean;
   styles?: object[];
 }
 


### PR DESCRIPTION
Prompted by issue [#27](https://github.com/amaurymartiny/react-mapbox-gl-draw/issues/27).

fixes #27.