### PR TITLE
fix: Fix default_mode casing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ export interface DrawControlProps {
     combine_features: boolean;
     uncombine_features: boolean;
   }>;
-  default_mode?: string;
+  defaultMode?: string;
   displayControlsDefault?: boolean;
   keybindings?: boolean;
   modes?: object;


### PR DESCRIPTION
Should be `defaultMode` as written in the readme. I tried with `default_mode` just to check and it doesn't do anything